### PR TITLE
Update METIS build to ensure position-independent code

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -26,6 +26,11 @@ jobs:
             cc: "gcc-10", cxx: "g++-10", fc: "gfortran-10", python: "python", pip: "pip"
           }
         - {
+            name: "Ubuntu 22.04 GCC 13",
+            os: ubuntu-22.04,
+            cc: "gcc-13", cxx: "g++-13", fc: "gfortran-13", python: "python3", pip: "pip3"
+          }
+        - {
             name: "macOS Monterey GCC 12",
             os: macos-12,
             cc: "gcc-12", cxx: "g++-12", fc: "gfortran-12", python: "python3", pip: "pip3"

--- a/src/utilities/build_libs.py
+++ b/src/utilities/build_libs.py
@@ -655,8 +655,9 @@ class METIS(package):
         return self.config_dict
 
     def build(self):
+        build_dir = os.getcwd()
         build_lines = [
-            "GKLIB_PATH=$(realpath GKlib)",
+            "GKLIB_PATH={0}".format(os.path.join(build_dir,"GKlib")),
             "rm -rf build",
             "mkdir -p build",
             "cd build",

--- a/src/utilities/build_libs.py
+++ b/src/utilities/build_libs.py
@@ -656,7 +656,11 @@ class METIS(package):
 
     def build(self):
         build_lines = [
-            "make config cc={CC} cmake={CMAKE} prefix={METIS_ROOT}",
+            "GKLIB_PATH=$(realpath GKlib)",
+            "rm -rf build",
+            "mkdir -p build",
+            "cd build",
+            "{CMAKE} -DCMAKE_INSTALL_PREFIX={METIS_ROOT} -DCMAKE_C_COMPILER={CC} -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON -DGKLIB_PATH=$GKLIB_PATH .. ",
             "make -j{MAKE_THREADS}",
             "make install"
         ]


### PR DESCRIPTION
 This pull request updates `build_libs.py` to ensure the METIS library is built with position-independent code as required for inclusion in shared libraries (eg. python interfaces). Fixes #10.

Additionally, this pull request made the following changes to the common code
 - Add Ubuntu 22.04 variant to CI build
 
This pull request **does not** modify the any APIs or input files.

