### PR TITLE
Convert ThinCurr to use binary output format for history files

### DIFF
--- a/src/bin/thincurr_td.F90
+++ b/src/bin/thincurr_td.F90
@@ -29,7 +29,7 @@
 !---------------------------------------------------------------------------
 PROGRAM thincurr_td
 USE oft_base
-USE oft_io, ONLY: hdf5_create_timestep
+USE oft_io, ONLY: hdf5_create_timestep, oft_bin_file
 USE oft_mesh_type, ONLY: smesh
 USE oft_mesh_native, ONLY: native_read_nodesets, native_read_sidesets
 #ifdef HAVE_NCDF
@@ -190,7 +190,7 @@ LOGICAL, INTENT(in) :: direct
 INTEGER(4), INTENT(in) :: nplot
 TYPE(tw_sensors), INTENT(in) :: sensors
 !---
-INTEGER(4) :: i,j,k,ntimes_curr,ntimes_volt,ncols,itime,io_unit,io_unit2,neta,face,info,ind1
+INTEGER(4) :: i,j,k,ntimes_curr,ntimes_volt,ncols,itime,io_unit,neta,face,info,ind1
 REAL(8) :: uu,t,tmp,area,p2,p1,val_prev,dt_op
 REAL(8), ALLOCATABLE, DIMENSION(:) :: icoil_curr,icoil_dcurr,pcoil_volt,senout,jumpout,eta_check
 REAL(8), ALLOCATABLE, DIMENSION(:,:) :: curr_waveform,volt_waveform,cc_vals
@@ -199,6 +199,7 @@ CLASS(oft_vector), POINTER :: u,g
 TYPE(oft_native_dense_matrix), TARGET :: Lmat,Minv
 TYPE(oft_sum_matrix), TARGET :: fmat,bmat
 CLASS(oft_solver), POINTER :: linv
+TYPE(oft_bin_file) :: floop_hist,jumper_hist
 LOGICAL :: exists
 CHARACTER(LEN=4) :: pltnum
 CHARACTER(LEN=15) :: fmt_str
@@ -310,15 +311,26 @@ CALL u%get_local(vals)
 IF(sensors%nfloops>0)THEN
   WRITE(fmt_str,'(I6)')sensors%nfloops+1
   fmt_str='('//TRIM(fmt_str)//'E24.15)'
-  ALLOCATE(senout(sensors%nfloops))
+  ALLOCATE(senout(sensors%nfloops+1))
   senout=0.d0
   IF(ntimes_curr>0)CALL dgemv('N',sensors%nfloops,self%n_icoils,1.d0,self%Adr2sen, &
-    sensors%nfloops,icoil_curr,1,0.d0,senout,1)
-  OPEN(NEWUNIT=io_unit,FILE='floops.hist')
-  WRITE(io_unit,'(1000E24.15)')t,senout
+    sensors%nfloops,icoil_curr,1,0.d0,senout(2),1)
+  !---Setup history file
+  IF(oft_env%head_proc)THEN
+    floop_hist%filedesc = 'ThinCurr flux loop history file'
+    CALL floop_hist%setup('floops.hist')
+    CALL floop_hist%add_field('time', 'r8', desc="Simulation time [s]")
+    DO i=1,sensors%nfloops
+      CALL floop_hist%add_field(sensors%floops(i)%name, 'r8')
+    END DO
+    CALL floop_hist%write_header
+    CALL floop_hist%open
+    senout(1)=t
+    CALL floop_hist%write(data_r8=senout)
+  END IF
 END IF
 IF(sensors%njumpers>0)THEN
-  ALLOCATE(jumpout(sensors%njumpers))
+  ALLOCATE(jumpout(sensors%njumpers+1))
   DO j=1,sensors%njumpers
     tmp=0.d0
     val_prev=0.d0
@@ -337,10 +349,21 @@ IF(sensors%njumpers>0)THEN
     DO k=1,self%nholes
       tmp=tmp+vals(self%np_active+k)*sensors%jumpers(j)%hole_facs(k)
     END DO
-    jumpout(j)=tmp
+    jumpout(j+1)=tmp
   END DO
-  OPEN(NEWUNIT=io_unit2,FILE='jumpers.hist')
-  WRITE(io_unit2,'(1000E24.15)')t,jumpout
+  !---Setup history file
+  IF(oft_env%head_proc)THEN
+    jumper_hist%filedesc = 'ThinCurr current jumper history file'
+    CALL jumper_hist%setup('jumpers.hist')
+    CALL jumper_hist%add_field('time', 'r8', desc="Simulation time [s]")
+    DO i=1,sensors%njumpers
+      CALL jumper_hist%add_field(sensors%jumpers(i)%name, 'r8')
+    END DO
+    CALL jumper_hist%write_header
+    CALL jumper_hist%open
+    jumpout(1)=t
+    CALL jumper_hist%write(data_r8=jumpout)
+  END IF
 END IF
 !---Advance system in time
 DO i=1,nsteps
@@ -407,10 +430,11 @@ DO i=1,nsteps
   END IF
   IF(sensors%nfloops>0)THEN
     CALL dgemv('N',sensors%nfloops,self%nelems,1.d0,self%Ael2sen,sensors%nfloops, &
-      vals,1,0.d0,senout,1)
+      vals,1,0.d0,senout(2),1)
     IF(ntimes_curr>0)CALL dgemv('N',sensors%nfloops,self%n_icoils,1.d0,self%Adr2sen, &
-      sensors%nfloops,icoil_curr,1,1.d0,senout,1)
-    WRITE(io_unit,'(1000E24.15)')t,senout
+      sensors%nfloops,icoil_curr,1,1.d0,senout(2),1)
+    senout(1)=t
+    CALL floop_hist%write(data_r8=senout)
   END IF
   IF(sensors%njumpers>0)THEN
     DO j=1,sensors%njumpers
@@ -431,9 +455,10 @@ DO i=1,nsteps
       DO k=1,self%nholes
         tmp=tmp+vals(self%np_active+k)*sensors%jumpers(j)%hole_facs(k)
       END DO
-      jumpout(j)=tmp
+      jumpout(j+1)=tmp
     END DO
-    WRITE(io_unit2,'(1000E24.15)')t,jumpout
+    jumpout(1)=t
+    CALL jumper_hist%write(data_r8=jumpout)
   END IF
 END DO
 !---Copy solution to input
@@ -441,11 +466,11 @@ CALL u%get_local(vals)
 vec=vals
 !---Cleanup
 IF(sensors%nfloops>0)THEN
-  CLOSE(io_unit)
+  CALL floop_hist%close
   DEALLOCATE(senout)
 END IF
 IF(sensors%njumpers>0)THEN
-  CLOSE(io_unit2)
+  CALL jumper_hist%close
   DEALLOCATE(jumpout)
 END IF
 CALL u%delete()
@@ -474,12 +499,13 @@ INTEGER(4), INTENT(in) :: nsteps
 INTEGER(4), INTENT(in) :: nplot
 TYPE(tw_sensors), INTENT(in) :: sensors
 !---
-INTEGER(4) :: i,j,jj,k,ntimes_curr,ncols,itime,io_unit,io_unit2,face,ind1,ind2
+INTEGER(4) :: i,j,jj,k,ntimes_curr,ncols,itime,io_unit,face,ind1,ind2
 REAL(8) :: uu,t,tmp,area,tmp2,val_prev
 REAL(8), ALLOCATABLE, DIMENSION(:) :: bvals,coil_vec,senout,jumpout
 REAL(8), ALLOCATABLE, DIMENSION(:,:) :: cc_vals,coil_waveform
 REAL(8), POINTER, DIMENSION(:) :: vals
 CLASS(oft_vector), POINTER :: u
+TYPE(oft_bin_file) :: floop_hist,jumper_hist
 LOGICAL :: exists
 CHARACTER(LEN=4) :: pltnum
 WRITE(*,*)'Post-processing simulation'
@@ -511,15 +537,26 @@ END IF
 !
 CALL u%get_local(vals)
 IF(sensors%nfloops>0)THEN
-  ALLOCATE(senout(sensors%nfloops))
+  ALLOCATE(senout(sensors%nfloops+1))
   senout=0.d0
   IF(ntimes_curr>0)CALL dgemv('N',sensors%nfloops,self%n_icoils,1.d0,self%Adr2sen, &
-    sensors%nfloops,coil_vec,1,0.d0,senout,1)
-  OPEN(NEWUNIT=io_unit,FILE='floops.hist')
-  WRITE(io_unit,*)t,senout
+    sensors%nfloops,coil_vec,1,0.d0,senout(2),1)
+  !---Setup history file
+  IF(oft_env%head_proc)THEN
+    floop_hist%filedesc = 'ThinCurr flux loop history file'
+    CALL floop_hist%setup('floops.hist')
+    CALL floop_hist%add_field('time', 'r8', desc="Simulation time [s]")
+    DO i=1,sensors%nfloops
+      CALL floop_hist%add_field(sensors%floops(i)%name, 'r8')
+    END DO
+    CALL floop_hist%write_header
+    CALL floop_hist%open
+    senout(1)=t
+    CALL floop_hist%write(data_r8=senout)
+  END IF
 END IF
 IF(sensors%njumpers>0)THEN
-  ALLOCATE(jumpout(sensors%njumpers))
+  ALLOCATE(jumpout(sensors%njumpers+1))
   DO j=1,sensors%njumpers
     tmp=0.d0
     val_prev=0.d0
@@ -538,10 +575,21 @@ IF(sensors%njumpers>0)THEN
     DO k=1,self%nholes
       tmp=tmp+vals(self%np_active+k)*sensors%jumpers(j)%hole_facs(k)
     END DO
-    jumpout(j)=tmp
+    jumpout(j+1)=tmp
   END DO
-  OPEN(NEWUNIT=io_unit2,FILE='jumpers.hist')
-  WRITE(io_unit2,*)t,jumpout
+  !---Setup history file
+  IF(oft_env%head_proc)THEN
+    jumper_hist%filedesc = 'ThinCurr current jumper history file'
+    CALL jumper_hist%setup('jumpers.hist')
+    CALL jumper_hist%add_field('time', 'r8', desc="Simulation time [s]")
+    DO i=1,sensors%njumpers
+      CALL jumper_hist%add_field(sensors%jumpers(i)%name, 'r8')
+    END DO
+    CALL jumper_hist%write_header
+    CALL jumper_hist%open
+    jumpout(1)=t
+    CALL jumper_hist%write(data_r8=jumpout)
+  END IF
 END IF
 IF(compute_B)THEN
   IF(.NOT.ALLOCATED(cc_vals))ALLOCATE(cc_vals(3,self%mesh%nc))
@@ -593,10 +641,11 @@ DO i=1,nsteps
     !
     IF(sensors%nfloops>0)THEN
       IF(ntimes_curr>0)CALL dgemv('N',sensors%nfloops,self%nelems,1.d0,self%Ael2sen, &
-        sensors%nfloops,vals,1,0.d0,senout,1)
+        sensors%nfloops,vals,1,0.d0,senout(2),1)
       CALL dgemv('N',sensors%nfloops,self%n_icoils,1.d0,self%Adr2sen,sensors%nfloops, &
-        coil_vec,1,1.d0,senout,1)
-      WRITE(io_unit,*)t,senout
+        coil_vec,1,1.d0,senout(2),1)
+      senout(1)=t
+      CALL floop_hist%write(data_r8=senout)
     END IF
     IF(sensors%njumpers>0)THEN
       DO j=1,sensors%njumpers
@@ -617,19 +666,20 @@ DO i=1,nsteps
         DO k=1,self%nholes
           tmp=tmp+vals(self%np_active+k)*sensors%jumpers(j)%hole_facs(k)
         END DO
-        jumpout(j)=tmp
+        jumpout(j+1)=tmp
       END DO
-      WRITE(io_unit2,*)t,jumpout
+      jumpout(1)=t
+      CALL jumper_hist%write(data_r8=jumpout)
     END IF
   END IF
 END DO
 !---Cleanup
 IF(sensors%nfloops>0)THEN
-  CLOSE(io_unit)
+  CALL floop_hist%close()
   DEALLOCATE(senout)
 END IF
 IF(sensors%njumpers>0)THEN
-  CLOSE(io_unit2)
+  CALL jumper_hist%close()
   DEALLOCATE(jumpout)
 END IF
 CALL u%delete

--- a/src/tests/physics/test_thin_wall.py
+++ b/src/tests/physics/test_thin_wall.py
@@ -6,6 +6,7 @@ import numpy as np
 test_dir = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.abspath(os.path.join(test_dir, '..')))
 from oft_testing import run_OFT
+from oft_io import oft_histfile
 
 mu0 = np.pi*4.E-7
 
@@ -173,13 +174,9 @@ def validate_fr(fr_real, fr_imag, tols=(1.E-4, 1.E-4)):
     """
     Helper function to validate frequency-response results against test case.
     """
-    fr_run_real = []
-    fr_run_imag = []
-    with open('thincurr_fr.dat', 'r') as fid:
-        for line in fid:
-            vals = line.split()
-            fr_run_real.append(float(vals[1]))
-            fr_run_imag.append(float(vals[2]))
+    hist_file = oft_histfile('thincurr_fr.dat')
+    fr_run_real = [hist_file.data[field][0] for field in hist_file.field_tags]
+    fr_run_imag = [hist_file.data[field][1] for field in hist_file.field_tags]
     if not len(fr_run_real) == len(fr_real):
         print("FAILED: Number of sensors does not match")
         return False
@@ -202,11 +199,8 @@ def validate_td(sigs_final, tols=(1.E-8, 1.E-3)):
     """
     Helper function to validate time-dependent results against test case.
     """
-    td_sigs_final = []
-    with open('floops.hist', 'r') as fid:
-        for line in fid:
-            pass
-        td_sigs_final = [float(val) for val in line.split()]
+    hist_file = oft_histfile('floops.hist')
+    td_sigs_final = [hist_file.data[field][-1] for field in hist_file.field_tags]
     if not len(td_sigs_final) == len(sigs_final):
         print("FAILED: Number of sensors does not match")
         return False

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -8,6 +8,11 @@ foreach( file ${OFT_PY_HELPER_MODS} )
   install(FILES ${file} DESTINATION python COMPONENT app)
 endforeach()
 
+# Needed for testing
+if( OFT_BUILD_TESTS )
+  file( COPY oft_io.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/../tests )
+endif()
+
 # Scripts
 install(PROGRAMS build_xdmf.py DESTINATION python COMPONENT app)
 set( OFT_PYTHON_BINS build_xdmf.py ${OFT_PYTHON_BINS} CACHE INTERNAL "package_python_binaries" )

--- a/src/utilities/oft_io.py
+++ b/src/utilities/oft_io.py
@@ -8,18 +8,19 @@
 from __future__ import print_function
 import struct
 import re
+import argparse
 eol_byte = '\n'.encode()
-# Decode list for Python 3 compatibility
+
+
 def decode_list(list):
+    r'''Decode list for Python 3 compatibility'''
     return [val.decode("utf-8") for val in list]
-#----------------------------------------------------------------
-# Class for loading and analyzing a structured OFT binary file
-#----------------------------------------------------------------
+
+
 class oft_histfile:
-    #----------------------------------------------------------------
-    # Load and parse binary file into Python representation
-    #----------------------------------------------------------------
+    r'''Class for loading and analyzing a structured OFT binary file'''
     def __init__(self,filename):
+        r'''Load and parse binary file into Python representation'''
         self.filename = filename
         self.header = []
         self.nlines = 0
@@ -76,8 +77,9 @@ class oft_histfile:
                     k += nfields
             else:
                 self.data[self.field_tags[0]].append(zip(*[iter(tmp)]*self.dim[0]))
-    #
+
     def setup_sizes(self, data_reg):
+        r'''Reader header information and setup binary reads'''
         base_dict = {}
         self.dim = None
         for line in self.content[:data_reg].split(eol_byte):
@@ -104,6 +106,9 @@ class oft_histfile:
         self.field_tags = []
         for field in base_dict['fields'].split():
             self.field_tags.append(field)
+        self.field_descriptions = {}
+        for field, description in base_dict['descriptions'].items():
+            self.field_descriptions[field] = description.strip()
         #
         self.field_types = []
         self.field_sizes = []
@@ -137,8 +142,9 @@ class oft_histfile:
             for (ind, fsize) in enumerate(self.field_sizes):
                 self.line_length += fsize*self.field_repeats[ind]
                 self.line_fmt += self.field_types[ind]*self.field_repeats[ind]
-    #
+
     def setup_sizes_legacy(self):
+        r'''Reader header information and setup binary reads using legacy format'''
         self.offset = 4
         tmp = struct.unpack_from("i",self.content,offset=self.offset)
         self.offset += 12
@@ -200,10 +206,9 @@ class oft_histfile:
                 self.line_length += fsize
                 self.line_fmt += self.field_types[ind]
         return
-    #----------------------------------------------------------------
-    # Convert data to MATLAB format and save
-    #----------------------------------------------------------------
+
     def save_to_matlab(self,filename):
+        r'''Convert data to MATLAB format'''
         try:
             import scipy.io as sio
         except:
@@ -212,10 +217,23 @@ class oft_histfile:
         else:
             print("Converting file to MATLAB format")
             sio.savemat(filename, self.data, oned_as='row')
-    #----------------------------------------------------------------
-    # Print information about the file
-    #----------------------------------------------------------------
+
+    def save_to_hdf5(self,filename):
+        r'''Convert data to HDF5 format'''
+        try:
+            import h5py
+        except:
+            print("Unable to load H5PY")
+            raise
+        else:
+            print("Converting file to HDF5 format")
+            with h5py.File(filename, 'w') as fid:
+                for (ind, field) in enumerate(self.field_tags):
+                    fid[field] = self.data[field]
+                    fid[field].attrs['description'] = self.field_descriptions[field]
+
     def __repr__(self):
+        r'''Print information about the file'''
         result = "\nOFT History file: {0}\n".format(self.filename)
         result += "  Number of fields = {0}\n".format(self.nfields)
         result += "  Number of entries = {0}\n".format(self.nlines)
@@ -225,17 +243,23 @@ class oft_histfile:
         #
         for (ind, field) in enumerate(self.field_tags):
             if field is not None:
-                result += '    {0} {1} ({2})\n'.format(field, self.field_types[ind], self.field_repeats[ind])
+                result += '    {0}: {3} ({1}{2})\n'.format(field, self.field_types[ind], self.field_repeats[ind], self.field_descriptions[field])
         return result
 #
 if __name__ == "__main__":
-    import sys
-    nfiles = len(sys.argv) - 1
-    if nfiles > 0:
-        files = sys.argv[1:]
-    else:
-        files = ['xmhd.hist']
-    for file in files:
+    parser = argparse.ArgumentParser()
+    parser.description = "Pre-processing script for mesh files"
+    parser.add_argument("--files", type=str, default=None, nargs='+', required=True, help="Files to view or convert")
+    parser.add_argument("--convert_hdf5", action="store_true", default=False, help="Convert files to HDF5? (default: False)")
+    parser.add_argument("--convert_matlab", action="store_true", default=False, help="Convert files to MATLAB? (default: False)")
+    options = parser.parse_args()
+
+    for file in options.files:
         hist_file = oft_histfile(file)
         file_prefix = file.split('.')[0]
-        hist_file.save_to_matlab(file_prefix + ".mat")
+        if options.convert_hdf5:
+            hist_file.save_to_hdf5(file_prefix + ".h5")
+        if options.convert_matlab:
+            hist_file.save_to_matlab(file_prefix + ".mat")
+        if not (options.convert_hdf5 or options.convert_matlab):
+            print(hist_file)


### PR DESCRIPTION
This pull request switches flux loop and jumper output in ThinCurr runs to use the OFT binary output history file format, including:
 - Add support for converting binary output files to HDF5
 - Update tests to use new format

This pull request **does not** modify any APIs or input files. This pull request **does** modify output files for ThinCurr runs.


 