### PR TITLE
ThinCurr: Correct resistivity units on filament coils to SI, fixes #30

### DIFF
--- a/src/physics/thin_wall.F90
+++ b/src/physics/thin_wall.F90
@@ -1594,7 +1594,8 @@ DO i=1,tw_obj%n_vcoils
     END DO
     tw_obj%vcoils(i)%Rself = tw_obj%vcoils(i)%Rself + tw_obj%vcoils(i)%res_per_len(j)*dl
   END DO
-  WRITE(*,"(A,1X,I4,A,ES12.4)")"  pCoil",i,": R [Ohm] = ",tw_obj%vcoils(i)%Rself*pi*4.d-7
+  WRITE(*,"(A,1X,I4,A,ES12.4)")"  pCoil",i,": R [Ohm] = ",tw_obj%vcoils(i)%Rself !*pi*4.d-7
+  tw_obj%vcoils(i)%Rself = tw_obj%vcoils(i)%Rself/mu0 ! Convert to magnetic units
   !
   eta_add=tw_obj%vcoils(i)%Rself
   j_add(1)=tw_obj%np_active+tw_obj%nholes+i

--- a/src/tests/physics/test_thin_wall.py
+++ b/src/tests/physics/test_thin_wall.py
@@ -100,7 +100,7 @@ def thin_wall_setup(meshfile,run_type,direct_flag,freq=0.0,fr_limit=0,eta=10.0,
     if vcoils is not None:
         coil_string += '<vcoils>\n'
         for pcoil in vcoils:
-            coil_string += '<coil_set type="2" res_per_len="10.0" radius="1.E-2"><coil npts="{0}">\n'.format(nPhi)
+            coil_string += '<coil_set type="2" res_per_len="1.256637E-5" radius="1.E-2"><coil npts="{0}">\n'.format(nPhi)
             R = pcoil[0]; Z = pcoil[1]
             for i in range(nPhi):
                 phi = i*phi_fac


### PR DESCRIPTION
This pull request corrects the resistivity of filament coils in ThinCurr to be consistent with SI units (`res_per_len` in [Ohm/m]), including:
 - Update resistivity per length in regression tests

This pull request **does no**t modify any APIs. This pull request **does** modify the effect of the `res_per_len` attribute on `<coil_set>` or `<coil>` groups in a `<vcoils>` set in the `<thincurr>` group in XML input files.