### PR TITLE
Add website CI build with artifacts for pull requests

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -2,9 +2,9 @@
 name: Build and deploy OFT website using GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting main or gh-pages branch (deploy on gh-pages only)
   push:
-    branches: ["gh-pages"]
+    branches: ["gh-pages", "main"]
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -78,7 +78,7 @@ jobs:
 
   # Deployment job
   deploy:
-    if: github.event_name != 'pull_request'
+    if: github.ref == 'ref/head/gh-pages'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -5,6 +5,8 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["gh-pages"]
+  pull_request:
+    types: [opened, reopened, synchronize]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -61,12 +63,22 @@ jobs:
           chmod -c -R +rX "_site/" | while read line; do
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
+        
+      - name: Upload actions artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pull_${{ github.event.pull_request.number }}-website
+          path: _site/
+          overwrite: true
 
-      - name: Upload artifact
+      - name: Upload pages artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -67,10 +67,18 @@ jobs:
       - name: Upload actions artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
+        id: artifact-upload-step
         with:
           name: pull_${{ github.event.pull_request.number }}-website
           path: _site/
           overwrite: true
+
+      - name: Add artifact to PR
+        if: github.event_name == 'pull_request'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            An updated build of the documentation for this PR has been completed :incoming_envelope:. It can be accessed at ${{ steps.artifact-upload-step.outputs.artifact-url }}.
 
       - name: Upload pages artifact
         if: github.event_name != 'pull_request'

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -43,7 +43,14 @@ jobs:
       - name: Create build dir
         run: mkdir build_docs
 
-      - name: Configure OFT documentation
+      - name: Configure OFT documentation (nightly)
+        if: github.ref != 'ref/head/gh-pages'
+        shell: bash
+        working-directory: build_docs
+        run: cmake -DOFT_BUILD_DOCS:BOOL=ON -DOFT_DOCS_ONLY:BOOL=ON -DOFT_PACKAGE_NIGHTLY:BOOL=ON ../src
+      
+      - name: Configure OFT documentation (deploy)
+        if: github.ref == 'ref/head/gh-pages'
         shell: bash
         working-directory: build_docs
         run: cmake -DOFT_BUILD_DOCS:BOOL=ON -DOFT_DOCS_ONLY:BOOL=ON -DOFT_PACKAGE_NIGHTLY:BOOL=OFF ../src
@@ -65,7 +72,7 @@ jobs:
           done
         
       - name: Upload actions artifact
-        if: github.event_name == 'pull_request'
+        if: github.ref != 'ref/head/gh-pages'
         uses: actions/upload-artifact@v4
         with:
           name: pull_${{ github.event.pull_request.number }}-website
@@ -73,7 +80,7 @@ jobs:
           overwrite: true
 
       - name: Upload pages artifact
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'ref/head/gh-pages'
         uses: actions/upload-pages-artifact@v3
 
   # Deployment job

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -67,18 +67,10 @@ jobs:
       - name: Upload actions artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
-        id: artifact-upload-step
         with:
           name: pull_${{ github.event.pull_request.number }}-website
           path: _site/
           overwrite: true
-
-      - name: Add artifact to PR
-        if: github.event_name == 'pull_request'
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            An updated build of the documentation for this PR has been completed :incoming_envelope:. It can be accessed at ${{ steps.artifact-upload-step.outputs.artifact-url }}.
 
       - name: Upload pages artifact
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
This pull request adds functionality to build the website for Open FUSION Toolkit for pull requests to support debugging of documentation changes.

This pull request **does not** modify any APIs or input files.