### PR TITLE
TokaMaker: Add error handling to `.save_eqdsk()` (failed tracing)

### DIFF
--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -4665,6 +4665,7 @@ real(8), pointer :: ptout(:,:)
 real(8), parameter :: tol=1.d-10
 integer(4) :: i,j,cell
 type(gsinv_interp), target :: field
+CHARACTER(LEN=80) :: error_str
 !---
 raxis=gseq%o_point(1)
 zaxis=gseq%o_point(2)
@@ -4737,8 +4738,8 @@ do j=1,nr
   pt_last=pt
   !---Skip point if trace fails
   if(active_tracer%status/=1)THEN
-    WRITE(*,*)j,pt
-    CALL oft_warn("gs_get_qprof: Trace did not complete")
+    WRITE(error_str,"(A,F10.4)")"gs_get_qprof: Trace did not complete at psi = ",1.d0-psi_q(j)
+    CALL oft_warn(error_str)
     CYCLE
   end if
   IF(j==1)THEN

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1273,7 +1273,10 @@ class TokaMaker():
             zbounds = numpy.r_[self.lim_contour[:,1].min(), self.lim_contour[:,1].max()]
             dr = zbounds[1]-zbounds[0]
             zbounds += numpy.r_[-1.0,1.0]*dr*0.05
-        tokamaker_save_eqdsk(cfilename,c_int(nr),c_int(nz),rbounds,zbounds,crun_info,c_double(lcfs_pad))
+        cstring = c_char_p(b""*200)
+        tokamaker_save_eqdsk(cfilename,c_int(nr),c_int(nz),rbounds,zbounds,crun_info,c_double(lcfs_pad),cstring)
+        if cstring.value != b'':
+            raise Exception(cstring.value)
 
     def eig_wall(self,neigs=4,pm=False):
         '''! Compute eigenvalues (1 / Tau_L/R) for conducting structures

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -199,7 +199,7 @@ tokamaker_get_limiter = ctypes_subroutine(oftpy_lib.tokamaker_get_limiter, #(np,
     [c_int_ptr,c_double_ptr_ptr])
 
 tokamaker_save_eqdsk = ctypes_subroutine(oftpy_lib.tokamaker_save_eqdsk, #(filename,nr,nz,rbounds,zbounds,run_info,psi_pad)
-    [c_char_p, c_int, c_int, ctypes_numpy_array(numpy.float64,1), ctypes_numpy_array(numpy.float64,1), c_char_p, c_double])
+    [c_char_p, c_int, c_int, ctypes_numpy_array(numpy.float64,1), ctypes_numpy_array(numpy.float64,1), c_char_p, c_double, c_char_p])
 ## @endcond
 
 

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -920,7 +920,7 @@ END SUBROUTINE tokamaker_set_coil_vsc
 !------------------------------------------------------------------------------
 !> Needs docs
 !------------------------------------------------------------------------------
-SUBROUTINE tokamaker_save_eqdsk(filename,nr,nz,rbounds,zbounds,run_info,psi_pad) BIND(C,NAME="tokamaker_save_eqdsk")
+SUBROUTINE tokamaker_save_eqdsk(filename,nr,nz,rbounds,zbounds,run_info,psi_pad,error_str) BIND(C,NAME="tokamaker_save_eqdsk")
 CHARACTER(KIND=c_char), INTENT(in) :: filename(80) !< Needs docs
 CHARACTER(KIND=c_char), INTENT(in) :: run_info(36) !< Needs docs
 INTEGER(c_int), VALUE, INTENT(in) :: nr !< Needs docs
@@ -928,11 +928,13 @@ INTEGER(c_int), VALUE, INTENT(in) :: nz !< Needs docs
 REAL(c_double), INTENT(in) :: rbounds(2) !< Needs docs
 REAL(c_double), INTENT(in) :: zbounds(2) !< Needs docs
 REAL(c_double), VALUE, INTENT(in) :: psi_pad !< Needs docs
+CHARACTER(KIND=c_char), INTENT(out) :: error_str(80) !< Needs docs
 CHARACTER(LEN=36) :: run_info_f
-CHARACTER(LEN=80) :: filename_tmp,lim_file
+CHARACTER(LEN=80) :: filename_tmp,lim_file,error_flag
 CALL copy_string_rev(run_info,run_info_f)
 CALL copy_string_rev(filename,filename_tmp)
 lim_file='none'
-CALL gs_save_eqdsk(gs_global,filename_tmp,nr,nz,rbounds,zbounds,run_info_f,lim_file,psi_pad)
+CALL gs_save_eqdsk(gs_global,filename_tmp,nr,nz,rbounds,zbounds,run_info_f,lim_file,psi_pad,error_flag)
+CALL copy_string(TRIM(error_flag),error_str)
 END SUBROUTINE tokamaker_save_eqdsk
 END MODULE tokamaker_f


### PR DESCRIPTION
This pull request adds error handling to `OpenFUSIONToolkit.TokaMaker.TokaMaker.save_eqdsk()`

Additionally, the following changes to the core code were made:
- Update error reporting in `TokaMaker.get_q()` to report flux coordinate where tracing failed

This pull request **does not** modify any existing APIs or input file settings. 

