### PR TITLE
Fix compile error on Windows (WSL) due to carriage returns in git output

### DIFF
--- a/src/include/create_git_header.sh
+++ b/src/include/create_git_header.sh
@@ -2,8 +2,8 @@
 HAVE_GIT=$(git status 1>/dev/null 2>&1; echo $?)
 if [[ "${HAVE_GIT}" -eq 0 ]]
 then
-  GITBRANCH=$(git branch | grep "*" | sed "s/* //" | sed "s/ /_/g" | sed -e "s/[()]//g")
-  GITVERSION=$(git rev-parse --short HEAD)
+  GITBRANCH=$(git branch | grep "*" | sed "s/* //" | sed "s/ /_/g" | sed -e "s/[()]//g" | sed 's/\r//g')
+  GITVERSION=$(git rev-parse --short HEAD | sed 's/\r//g')
 else
   GITBRANCH=unknown
   GITVERSION=unknown


### PR DESCRIPTION
This pull request fixes a compile error that can occur on certain Windows (WSL) machines due to carriage returns in git output.

This pull request **does not** modify any APIs or input files.