### PR TITLE
Added current distribution setter for coils

### DIFF
--- a/src/physics/grad_shaf.F90
+++ b/src/physics/grad_shaf.F90
@@ -1766,6 +1766,56 @@ DEALLOCATE(btmp)
 ! self%timing(2)=self%timing(2)+(omp_get_wtime()-t1)
 end subroutine gs_coil_source
 !---------------------------------------------------------------------------
+!> Calculates field contribution due to coil with non-uniform conductivity
+!---------------------------------------------------------------------------
+subroutine gs_coil_source_distributed(self,iCoil,a,b)
+class(gs_eq), intent(inout) :: self !< G-S object
+integer(4), intent(in) :: iCoil !< Coil index
+REAL(8), POINTER, DIMENSION(:), intent(in) :: a !< Normalized local conductivity
+CLASS(oft_vector), intent(inout) :: b !< Coil field
+real(r8), pointer, dimension(:) :: btmp
+real(8) :: psitmp,goptmp(3,3),det,pt(3),v,t1,nturns
+real(8), allocatable :: rhs_loc(:),rop(:)
+integer(4) :: j,m,l,k
+integer(4), allocatable :: j_lag(:)
+NULLIFY(btmp)
+CALL b%set(0.d0)
+CALL b%get_local(btmp)
+!$omp parallel private(j,rhs_loc,j_lag,goptmp,v,m,det,pt,psitmp,l,rop,nturns)
+allocate(rhs_loc(oft_blagrange%nce))
+allocate(rop(oft_blagrange%nce))
+allocate(j_lag(oft_blagrange%nce))
+DO j=1,smesh%nc !For each cell
+  nturns=self%coil_nturns(smesh%reg(j),iCoil) !Read number of iCoil's turns associated with this cell
+  IF(ABS(nturns)<1.d-10)CYCLE !Only execute for nonzero turns
+  call oft_blagrange%ncdofs(j,j_lag) !Load weight indices for cell j into j_lag
+  rhs_loc=0.d0
+  do m=1,oft_blagrange%quad%np !For each point in the quad corresponding to cell j
+    call smesh%jacobian(j,oft_blagrange%quad%pts(:,m),goptmp,v) !Writes to goptmp and v
+    det=v*oft_blagrange%quad%wts(m) !Multiply det of jacobian (volume) by quad point weight
+    DO l=1,oft_blagrange%nce !For each element in cell j
+      !Evaluate contribution from point m by lagrange interpolation, Write the value to rop(l)
+      CALL oft_blag_eval(oft_blagrange,j,l,oft_blagrange%quad%pts(:,m),rop(l)) 
+    END DO
+    !$omp simd
+    do l=1,oft_blagrange%nce !For each element in cell j
+      !Add the interpolated contribution, scaled by determinant and current distribution
+      rhs_loc(l)=rhs_loc(l)+rop(l)*det*a(j_lag(l))
+    end do
+  end do
+  !---Get local to global DOF mapping
+  do l=1,oft_blagrange%nce !For each element
+    m = j_lag(l) !Convert local index to global index (remember, j_lag is changed every cell)
+    !$omp atomic
+    btmp(m)=btmp(m)+rhs_loc(l)*nturns !Add the field contribution due to this cell element to the global field
+  end do
+END DO
+deallocate(rhs_loc,j_lag,rop)
+!$omp end parallel
+CALL b%restore_local(btmp,add=.TRUE.)
+DEALLOCATE(btmp)
+end subroutine gs_coil_source_distributed
+!---------------------------------------------------------------------------
 ! SUBROUTINE gs_cond_source
 !---------------------------------------------------------------------------
 !> Needs Docs
@@ -1949,6 +1999,55 @@ mutual=mu0*2.d0*pi*mutual!/self%coil_regions(iCoil)%area
 DEALLOCATE(btmp)
 ! self%timing(2)=self%timing(2)+(omp_get_wtime()-t1)
 end subroutine gs_coil_mutual
+!---------------------------------------------------------------------------
+!> Compute inductance between a coil with non-uniform current distribution and given poloidal flux
+!---------------------------------------------------------------------------
+subroutine gs_coil_mutual_distributed(self, iCoil, b, a, mutual)
+class(gs_eq), intent(inout) :: self !< G-S object
+integer(4), intent(in) :: iCoil !< Coil index
+CLASS(oft_vector), intent(inout) :: b !< \f$ \psi \f$ for mutual calculation
+REAL(8), POINTER, DIMENSION(:), intent(in) :: a !< Normalized local conductivity
+real(8), intent(out) :: mutual !< Mutual inductance \f$ \int I_C \psi dV / I_C \f$
+real(r8), pointer, dimension(:) :: btmp
+real(8) :: goptmp(3,3),det,pt(3),v,t1,psi_tmp,nturns,j_phi
+real(8), allocatable :: rhs_loc(:),cond_fac(:),rop(:)
+integer(4) :: j,m,l,k
+integer(4), allocatable :: j_lag(:)
+logical :: curved
+! t1=omp_get_wtime()
+!---
+NULLIFY(btmp)
+CALL b%get_local(btmp)
+!---
+mutual=0.d0
+!$omp parallel private(j,j_lag,curved,goptmp,v,m,det,pt,l,rop,nturns) reduction(+:mutual)
+allocate(rop(oft_blagrange%nce))
+allocate(j_lag(oft_blagrange%nce))
+!$omp do schedule(static,1)
+DO j=1,smesh%nc
+  nturns=self%coil_nturns(smesh%reg(j),iCoil)
+  IF(ABS(nturns)<1.d-10)CYCLE
+  call oft_blagrange%ncdofs(j,j_lag) !Load map onto j_lag
+  do m=1,oft_blagrange%quad%np
+    call smesh%jacobian(j,oft_blagrange%quad%pts(:,m),goptmp,v)
+    pt=smesh%log2phys(j,oft_blagrange%quad%pts(:,m))
+    det=v*oft_blagrange%quad%wts(m)
+    psi_tmp=0.d0
+    j_phi=0.d0
+    DO l=1,oft_blagrange%nce
+      CALL oft_blag_eval(oft_blagrange,j,l,oft_blagrange%quad%pts(:,m),rop(l))
+      psi_tmp=psi_tmp+btmp(j_lag(l))*rop(l)
+      j_phi=j_phi+a(j_lag(l))*rop(l)
+    END DO
+    mutual = mutual + psi_tmp*det*nturns*j_phi
+  end do
+end do
+deallocate(j_lag,rop)
+!$omp end parallel
+mutual=mu0*2.d0*pi*mutual!/self%coil_regions(iCoil)%area
+DEALLOCATE(btmp)
+! self%timing(2)=self%timing(2)+(omp_get_wtime()-t1)
+end subroutine gs_coil_mutual_distributed
 !---------------------------------------------------------------------------
 !> Compute inductance between plasma current and given poloidal flux
 !---------------------------------------------------------------------------

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_core.py
@@ -1362,6 +1362,19 @@ class TokaMaker():
         if cstring.value != b'':
             raise Exception(cstring.value)
 
+    def set_coil_current_dist(self,iCoil,curr_vals):
+        '''! Overwrite current distribution associated with coil to model non-uniform conductivity.
+
+        @param iCoil Coil index
+        @param curr_vals Modified current values
+        '''
+        if curr_vals.shape[0] != self.np:
+            raise IndexError('Incorrect shape of "psi0", should be [np]')
+        if iCoil <= 0:
+            raise IndexError("iCoil must be between 1 and ncoils")
+        curr_vals = numpy.ascontiguousarray(curr_vals, dtype=numpy.float64)
+        tokamaker_set_coil_current_dist(c_int(iCoil),curr_vals)
+
     def eig_wall(self,neigs=4,pm=False):
         r'''! Compute eigenvalues (\f$ 1 / \tau_{L/R} \f$) for conducting structures
 

--- a/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
+++ b/src/python/OpenFUSIONToolkit/TokaMaker/_interface.py
@@ -203,6 +203,9 @@ tokamaker_get_limiter = ctypes_subroutine(oftpy_lib.tokamaker_get_limiter, #(np,
 
 tokamaker_save_eqdsk = ctypes_subroutine(oftpy_lib.tokamaker_save_eqdsk, #(filename,nr,nz,rbounds,zbounds,run_info,psi_pad,rcentr,error_str)
     [c_char_p, c_int, c_int, ctypes_numpy_array(numpy.float64,1), ctypes_numpy_array(numpy.float64,1), c_char_p, c_double, c_double, c_bool, c_char_p, c_char_p])
+
+tokamaker_set_coil_current_dist = ctypes_subroutine(oftpy_lib.tokamaker_set_coil_current_dist,
+    [c_int, ctypes_numpy_array(numpy.float64,1)])
 ## @endcond
 
 

--- a/src/python/wrappers/tokamaker_f.F90
+++ b/src/python/wrappers/tokamaker_f.F90
@@ -23,12 +23,12 @@ USE oft_solver_utils, ONLY: create_cg_solver, create_diag_pre
 USE fem_base, ONLY: oft_afem_type
 USE oft_lag_basis, ONLY: oft_lag_setup_bmesh, oft_scalar_bfem, oft_blagrange, &
   oft_lag_setup
-USE oft_blag_operators, ONLY: oft_lag_brinterp
+USE oft_blag_operators, ONLY: oft_lag_brinterp, blag_zerob
 USE mhd_utils, ONLY: mu0
 USE axi_green, ONLY: green
 USE oft_gs, ONLY: gs_eq, gs_save_fields, gs_save_fgrid, gs_setup_walls, build_dels, &
   gs_fixed_vflux, gs_load_regions, gs_get_qprof, gs_trace_surf, gs_b_interp, gs_prof_interp, &
-  gs_plasma_mutual, gs_source
+  gs_plasma_mutual, gs_source, gs_coil_source_distributed, gs_vacuum_solve, gs_coil_mutual, gs_coil_mutual_distributed
 USE oft_gs_util, ONLY: gs_save, gs_load, gs_analyze, gs_comp_globals, gs_save_eqdsk, &
   gs_profile_load, sauter_fc, gs_calc_vloop
 USE oft_gs_fit, ONLY: fit_gs, fit_pm
@@ -1000,4 +1000,32 @@ ELSE
 END IF
 CALL copy_string(TRIM(error_flag),error_str)
 END SUBROUTINE tokamaker_save_eqdsk
+!---------------------------------------------------------------------------
+!> Sets distribution of current in coil by normalized field curr_vals
+!---------------------------------------------------------------------------
+SUBROUTINE tokamaker_set_coil_current_dist(iCoil,curr_vals) BIND(C,NAME="tokamaker_set_coil_current_dist")
+INTEGER(c_int), VALUE, INTENT(in) :: iCoil !< Coil index
+TYPE(c_ptr), VALUE, INTENT(in) :: curr_vals !< Relative current intensity
+REAL(8), POINTER, DIMENSION(:) :: vals_tmp
+INTEGER(4) :: i
+class(oft_vector), pointer :: tmp_vec
+CALL c_f_pointer(curr_vals, vals_tmp, [gs_global%psi%n]) ! Maps curr_vals from C into fortran array
+! Update coil flux to overwrite old uniform distribution
+NULLIFY(tmp_vec)
+call gs_global%psi%new(tmp_vec)
+CALL gs_coil_source_distributed(gs_global,iCoil,vals_tmp,tmp_vec) ! This function needs to be defined
+CALL blag_zerob(tmp_vec)
+CALL gs_vacuum_solve(gs_global,gs_global%psi_coil(iCoil)%f,tmp_vec)
+! Update coil mutual inductances
+DO i=1,gs_global%ncoils
+  CALL gs_coil_mutual(gs_global,i,gs_global%psi_coil(iCoil)%f,gs_global%Lcoils(i,iCoil))
+  gs_global%Lcoils(iCoil,i)=gs_global%Lcoils(i,iCoil)
+  IF(i==iCoil)THEN
+    CALL gs_coil_mutual_distributed(gs_global,i,gs_global%psi_coil(iCoil)%f,vals_tmp,gs_global%Lcoils(i,iCoil))
+  ELSE
+    CALL gs_coil_mutual(gs_global,i,gs_global%psi_coil(iCoil)%f,gs_global%Lcoils(i,iCoil))
+    gs_global%Lcoils(iCoil,i)=gs_global%Lcoils(i,iCoil)
+  END IF
+END DO
+END SUBROUTINE tokamaker_set_coil_current_dist
 END MODULE tokamaker_f


### PR DESCRIPTION
Can now set non-uniform current distribution in coils by supplying a vector of the normalized current distribution function over space. Coil contribution to flux is fixed/overwritten, and mutual inductance matrix is properly updated.
